### PR TITLE
端末を利用するユーザー情報と、端末のアプリケーション使用情報を取得できる様にした

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__jamf-pro__getDevicesBatch",
+      "mcp__jamf-pro__getDeviceDetails",
+      "Bash(npm run build:*)",
+      "mcp__jamf-pro__searchDevices",
+      "mcp__jamf-pro__getComputerApplicationUsage"
+    ]
+  },
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": [
+    "jamf-pro"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ pids
 *.pid
 *.seed
 *.pid.lock
+
+# local mcp config
+.mcp.json

--- a/.mcp_sample.json
+++ b/.mcp_sample.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "jamf-pro": {
+      "command": "node",
+      "args": ["<your path to jamf-mcp-server>/dist/index.js"],
+      "env": {
+        "JAMF_URL": "<your jamf pro url>",
+        "JAMF_CLIENT_ID": "<your jamf client id>",
+        "JAMF_CLIENT_SECRET": "<your jamf client secret>",
+        "JAMF_READ_ONLY": "true"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Model Context Protocol (MCP) server that enables AI assistants to interact with Jamf Pro for Apple device management. The server provides comprehensive device management capabilities through the Jamf Pro API.
+
+## Essential Commands
+
+### Development
+
+```bash
+npm run dev          # Run in development mode with hot reload
+npm run build        # Compile TypeScript to JavaScript (dist/)
+npm run serve        # Run production build
+npm run inspector    # Launch MCP Inspector for debugging
+```
+
+### Testing
+
+```bash
+npm test             # Run all tests
+npm test -- --coverage  # Run tests with coverage report
+npm test -- path/to/test.spec.ts  # Run specific test file
+```
+
+### Linting
+
+```bash
+npm run lint         # Run ESLint on TypeScript files
+npm run lint:fix     # Auto-fix linting issues
+```
+
+## Architecture
+
+### Client Architecture Evolution
+
+The codebase has multiple Jamf client implementations to handle different API versions and error scenarios:
+
+1. **jamf-client.ts**: Modern API v2 client (primary)
+2. **jamf-client-classic.ts**: Classic API v1 client (legacy endpoints)
+3. **jamf-client-hybrid.ts**: Combines Modern + Classic APIs (seamless fallback)
+4. **jamf-client-enhanced.ts**: Enhanced error handling with retry logic
+
+The server automatically selects the appropriate client based on the `JAMF_ENHANCED_MODE` environment variable.
+
+### MCP Integration Structure
+
+- **Tools** (`src/tools/`): Define callable functions exposed to AI assistants
+- **Resources** (`src/resources/`): Provide data sources that can be read
+- **Prompts** (`src/prompts/`): Pre-defined workflow templates for common tasks
+
+### Authentication Flow
+
+The server supports two authentication methods:
+
+1. **OAuth2**: Uses client credentials flow with automatic token refresh
+2. **Basic Auth**: Username/password authentication (legacy)
+
+Authentication is configured via environment variables and automatically selected based on available credentials.
+
+### Error Handling Strategy
+
+- Custom error classes in `src/utils/errors.ts` for typed error handling
+- Axios interceptors for automatic retry on transient failures
+- Enhanced mode includes exponential backoff and circuit breaker patterns
+
+## Key Implementation Notes
+
+### API Version Handling
+
+When making API calls, the hybrid client automatically falls back from Modern API to Classic API if an endpoint is not available. This is critical for compatibility as Jamf Pro transitions between API versions.
+
+### Testing Approach
+
+- Unit tests mock the Jamf API responses using fixtures in `src/__tests__/fixtures/`
+- Integration tests require a live Jamf Pro instance (skipped in CI)
+- Coverage thresholds are enforced: 80% for functions/lines/statements, 70% for branches
+
+### Configuration
+
+- Local development: Use `.mcp.json` for API credentials (git-ignored)
+- Production: Use environment variables (JAMF_SERVER_URL, JAMF_CLIENT_ID, etc.)
+- Claude Desktop: Configure via `.claude/settings.local.json`
+
+### Common Pitfalls
+
+- Many Jamf API endpoints have different response formats between v1 and v2
+- Device IDs can be strings or numbers depending on the API version
+- Rate limiting may occur with frequent API calls - enhanced mode handles this automatically
+- OAuth token refresh must be handled before expiration (built into enhanced client)
+
+## Development Workflow
+
+When adding new Jamf functionality:
+
+1. Check if the endpoint exists in both Modern and Classic APIs
+2. Implement in the appropriate client file(s)
+3. Add the tool definition in `src/tools/index.ts`
+4. Include proper Zod validation for parameters
+5. Add tests with mocked API responses
+6. Update the README.md with usage examples if it's a major feature
+
+## MCP Server Specifics
+
+This server runs as an MCP server that can be integrated with:
+
+- Claude Desktop (via `.claude/settings.local.json`)
+- Any MCP-compatible client
+
+The server exposes ~50 tools for device management, policy deployment, script execution, and reporting. Each tool includes built-in parameter validation and confirmation requirements for destructive operations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamf-mcp-server",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jamf-mcp-server",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -14,7 +14,7 @@
         "zod": "^3.23.0"
       },
       "bin": {
-        "jamf-mcp-server": "dist/index.js"
+        "jamf-mcp-server": "dist/index-main.js"
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",
@@ -2111,13 +2111,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -3566,9 +3566,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",

--- a/src/jamf-client-hybrid.ts
+++ b/src/jamf-client-hybrid.ts
@@ -380,6 +380,28 @@ export class JamfApiClientHybrid {
   }
 
   /**
+   * Get computer application usage data
+   */
+  async getComputerApplicationUsage(id: string, startDate: string, endDate: string): Promise<any[]> {
+    await this.ensureAuthenticated();
+    
+    try {
+      // Use Classic API endpoint for application usage
+      console.error(`Getting application usage for computer ${id} from ${startDate} to ${endDate} using Classic API...`);
+      const response = await this.axiosInstance.get(`/JSSResource/computerapplicationusage/id/${id}/${startDate}_${endDate}`);
+      
+      // The Classic API returns data in format: { computer_application_usage: [...] }
+      // Extract the actual usage data array
+      const usageData = response.data.computer_application_usage || [];
+      
+      return usageData;
+    } catch (error) {
+      console.error(`Failed to get application usage for computer ${id}:`, error);
+      throw error;
+    }
+  }
+
+  /**
    * Get all computers (for compatibility)
    */
   async getAllComputers(limit: number = 1000): Promise<any[]> {

--- a/src/tools/index-compat.ts
+++ b/src/tools/index-compat.ts
@@ -17,6 +17,12 @@ const GetDeviceDetailsSchema = z.object({
   deviceId: z.string().describe('The Jamf device ID'),
 });
 
+const GetComputerApplicationUsageSchema = z.object({
+  deviceId: z.string().describe('The computer ID to get application usage for'),
+  startDate: z.string().describe('Start date in YYYY-MM-DD format'),
+  endDate: z.string().describe('End date in YYYY-MM-DD format'),
+});
+
 const UpdateInventorySchema = z.object({
   deviceId: z.string().describe('The device ID to update inventory for'),
 });
@@ -472,6 +478,28 @@ export function registerTools(server: Server, jamfClient: any): void {
             },
           },
           required: ['deviceId'],
+        },
+      },
+      {
+        name: 'getComputerApplicationUsage',
+        description: 'Get application usage data for a specific computer within a date range',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            deviceId: {
+              type: 'string',
+              description: 'The computer ID to get application usage for',
+            },
+            startDate: {
+              type: 'string',
+              description: 'Start date in YYYY-MM-DD format',
+            },
+            endDate: {
+              type: 'string',
+              description: 'End date in YYYY-MM-DD format',
+            },
+          },
+          required: ['deviceId', 'startDate', 'endDate'],
         },
       },
       {
@@ -1853,6 +1881,30 @@ export function registerTools(server: Server, jamfClient: any): void {
           const content: TextContent = {
             type: 'text',
             text: JSON.stringify(formatted, null, 2),
+          };
+
+          return { content: [content] };
+        }
+
+        case 'getComputerApplicationUsage': {
+          const { deviceId, startDate, endDate } = GetComputerApplicationUsageSchema.parse(args);
+          const usageData = await jamfClient.getComputerApplicationUsage(deviceId, startDate, endDate);
+          
+          const content: TextContent = {
+            type: 'text',
+            text: JSON.stringify({
+              deviceId,
+              dateRange: `${startDate} to ${endDate}`,
+              usageData: usageData.map((item: any) => ({
+                date: item.date,
+                applications: (item.apps || []).map((appData: any) => ({
+                  name: appData.name,
+                  version: appData.version,
+                  foregroundMinutes: appData.foreground,
+                  openMinutes: appData.open,
+                })),
+              })),
+            }, null, 2),
           };
 
           return { content: [content] };

--- a/src/tools/index-compat.ts
+++ b/src/tools/index-compat.ts
@@ -1830,6 +1830,8 @@ export function registerTools(server: Server, jamfClient: any): void {
                                  device.general?.remoteManagement?.managementUsername,
               serialNumber: device.general?.serial_number || device.general?.serialNumber,
               lastContactTime: device.general?.last_contact_time || device.general?.lastContactTime,
+              lastLoggedInUser: device.general?.lastLoggedInUsernameBinary,
+              lastLoggedInUserTimestamp: device.general?.lastLoggedInUsernameBinaryTimestamp,
             },
             hardware: {
               model: device.hardware?.model,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,11 +1,9 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { 
+import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
-  Tool,
   TextContent,
-  ImageContent,
-  EmbeddedResource,
+  Tool
 } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { JamfApiClientHybrid as JamfApiClient } from '../jamf-client-hybrid.js';


### PR DESCRIPTION
## 概要

- 端末詳細取得APIでこれまで取得していなかった `lastLoggedInUser` および `lastLoggedInUserTimestamp` を取得できるようにしました。
- 端末のアクティブ／非アクティブ判定のため、アプリケーション使用情報を取得できるツールを追加しました。

## リファレンス

- https://developer.jamf.com/jamf-pro/reference/get_v1-computers-inventory-detail-id
- https://developer.jamf.com/jamf-pro/reference/findcomputerapplicationusagebyid

## Copilot Summary

This pull request introduces a new tool for retrieving application usage data for Jamf-managed computers and updates configuration and documentation to support this feature. The most important changes include the implementation of the `getComputerApplicationUsage` method in the hybrid Jamf client, registration of the corresponding tool, and updates to sample configuration and documentation files.

**Jamf Client & Tooling Enhancements:**

* Added the `getComputerApplicationUsage` method to `JamfApiClientHybrid`, enabling retrieval of application usage data for a computer over a specified date range using the Classic Jamf API.
* Registered the new `getComputerApplicationUsage` tool in `src/tools/index-compat.ts`, including its input schema and handler logic for returning usage data in a structured format. [[1]](diffhunk://#diff-1f20ad19caf7872790b429bfc1d40bd40a9062d801c1fe89fa326a88ca02a071R20-R25) [[2]](diffhunk://#diff-1f20ad19caf7872790b429bfc1d40bd40a9062d801c1fe89fa326a88ca02a071R483-R504) [[3]](diffhunk://#diff-1f20ad19caf7872790b429bfc1d40bd40a9062d801c1fe89fa326a88ca02a071R1889-R1912)

**Configuration Updates:**

* Updated `.claude/settings.local.json` to allow the new tool and enable Jamf MCP server integration for Claude Desktop.
* Added a sample MCP server configuration for Jamf Pro in `.mcp_sample.json`, showing environment variable setup for local development.

**Documentation Improvements:**

* Created `CLAUDE.md` to provide an overview of the project, its architecture, development workflow, and key implementation notes for contributors and users.

**Minor Data Model Extension:**

* Extended the device details returned by the tool to include `lastLoggedInUser` and `lastLoggedInUserTimestamp` fields.