### PR TITLE
feat: getDeviceDetails で serial number を取得できる様にした

### DIFF
--- a/src/tools/index-compat.ts
+++ b/src/tools/index-compat.ts
@@ -1868,6 +1868,7 @@ export function registerTools(server: Server, jamfClient: any): void {
               totalRamMB: device.hardware?.total_ram || device.hardware?.totalRamMegabytes,
               batteryPercent: device.hardware?.battery_capacity || device.hardware?.batteryCapacityPercent,
               appleSilicon: device.hardware?.apple_silicon || device.hardware?.appleSilicon,
+              serialNumber: device.general?.serial_number || device.general?.serialNumber || device.hardware?.serial_number || device.hardware?.serialNumber,
             },
             userAndLocation: {
               username: device.location?.username || device.userAndLocation?.username,


### PR DESCRIPTION
## Copilot Summary

This pull request introduces a minor update to the device information mapping in the `registerTools` function. The change ensures that the `serialNumber` property is populated by checking multiple possible fields in the device data, improving compatibility with different data formats.

- Device information mapping:
  * Updated the `serialNumber` field in the `registerTools` function to check for both snake_case and camelCase variants in `device.general` and `device.hardware` objects.